### PR TITLE
Adding the ability to provide a transform function for transforming data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The default values are :
 ``` JavaScript
 {
 	url: function(id) { return id; }, // generate url for ajax call, id is the value of the node ID
+	transform: function(lines) { return lines; }, // transform the data to conform to the JSON array structure outlined below
 	minWidth: 40, // minimum width of one column
 	tabindex: 0, // default tabindex if it is undefined on the DOM element
 	carroussel: false, // If set to true, the user will go to the first item of the column if it use ↓ on the last item

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The ajax call must return a JSON array with the following structure:
    { 'id': 'ID of node 1', 'name': 'Name of node 1', 'parent': false }, // this node has no child
    { 'id': 'ID of node 2', 'name': 'Name of node 2', 'parent': true }, // this node has some children
    { 'id': 'ID of node 3', 'name': 'Name of node 3', 'parent': false }, // this node has no child
+   { 'id': 'ID of node 4', 'name': 'Name of node 4', 'parent': false, 'image': '../image.png' }, // this node has an image
 	// and so on…
 ]
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The default values are :
 {
 	url: function(id) { return id; }, // generate url for ajax call, id is the value of the node ID
 	transform: function(lines) { return lines; }, // transform the data to conform to the JSON array structure outlined below
+	preloadedData: {}, // A data object matching the JSON structure below that will be used before calls to 'url' to fetch data
+	initialPath: [], // The path to initialize the UI to.  This is an array of IDs.  Currently only works when using preloadedData.
 	minWidth: 40, // minimum width of one column
 	tabindex: 0, // default tabindex if it is undefined on the DOM element
 	carroussel: false, // If set to true, the user will go to the first item of the column if it use ↓ on the last item

--- a/js/jquery.miller.js
+++ b/js/jquery.miller.js
@@ -21,6 +21,7 @@
 			var currentAjaxRequest = null;
 			var settings = $.extend(true, {
 						'url': function(id) { return id; },
+						'transform': function(lines) { return lines; },
 						'tabindex': 0,
 						'minWidth': 40,
 						'carroussel': false,
@@ -310,6 +311,10 @@
 				}
 			;
 
+			var transformAndBuildColumn = function(data) {
+					buildColumn(settings.transform.call(miller, data));
+			};
+
 			var getLines = function(event) {
 					if (currentAjaxRequest) {
 						currentAjaxRequest.abort();
@@ -320,7 +325,7 @@
 						.addClass('parentLoading')
 					;
 
-					currentAjaxRequest = $.getJSON(settings.url($(this).data('id')), buildColumn)
+					currentAjaxRequest = $.getJSON(settings.url($(this).data('id')), transformAndBuildColumn)
 						.always(function() {
 								currentLine
 									.removeClass('parentLoading')
@@ -335,7 +340,7 @@
 				}
 			;
 
-			$.getJSON(settings.url(), buildColumn);
+			$.getJSON(settings.url(), transformAndBuildColumn);
 
 			return miller;
 		}

--- a/js/jquery.miller.js
+++ b/js/jquery.miller.js
@@ -325,7 +325,7 @@
 						.addClass('parentLoading')
 					;
 
-					currentAjaxRequest = $.getJSON(settings.url($(this).data('id')), transformAndBuildColumn)
+					currentAjaxRequest = $.getJSON(settings.url.call(miller, $(this).data('id')), transformAndBuildColumn)
 						.always(function() {
 								currentLine
 									.removeClass('parentLoading')
@@ -340,7 +340,7 @@
 				}
 			;
 
-			$.getJSON(settings.url(), transformAndBuildColumn);
+			$.getJSON(settings.url.call(miller), transformAndBuildColumn);
 
 			return miller;
 		}

--- a/js/jquery.miller.js
+++ b/js/jquery.miller.js
@@ -278,6 +278,11 @@
 									if (data['parent']) {
 										line.addClass('parent');
 									}
+									if (data['image']) {
+										$('<img>', { 'src': data['image']})
+											.prependTo(line)
+										;
+									}
 								}
 							);
 

--- a/js/jquery.miller.js
+++ b/js/jquery.miller.js
@@ -47,7 +47,10 @@
 						},
 						'pane': {
 							'options': {}
-						}
+						},
+                        'onClick' : function() {
+                            // No-op
+                        }
 					},
 					mixed
 				)
@@ -272,6 +275,7 @@
 										.data('id', data['id'])
 										.click(removeNextColumns)
 										.click(getLines)
+                                        .click(settings.onClick)
 										.appendTo(column)
 									;
 

--- a/js/jquery.miller.js
+++ b/js/jquery.miller.js
@@ -278,6 +278,9 @@
 									if (data['parent']) {
 										line.addClass('parent');
 									}
+									if (data['class']) {
+										line.addClass(data['class']);
+									}
 									if (data['image']) {
 										$('<img>', { 'src': data['image']})
 											.prependTo(line)


### PR DESCRIPTION
I've added the ability to provide a transform function that will be used on any data that is fetched.  This allows an existing REST service's data to work with this plugin without a change to the data returned by the REST service.

I've also made two small tweaks to the scope that is used when calling the 'url' function so that "this" is the plugin scope.  This is useful if one needs to get the current path (via this.miller('getPath')) in order to generate an appropriate url.  This seems to be congruous with the way toolbar.options and pane.options callbacks are executed.
